### PR TITLE
Add `staticFileGlobsIgnorePatterns` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You can pass a hash of configuration options to `SWPrecacheWebpackPlugin`:
 __plugin options__:
 *  `filename`: `[String]` - Service worker filename, default is `service-worker.js`
 *  `filepath`: `[String]` - Service worker path and name, default is to use `webpack.output.path` + `options.filename`.
+*  `staticFileGlobsIgnorePatterns`: `[RegExp]` - Define an optional array of regex patterns to filter out of staticFileGlobs (see below)
 
 [__`sw-precache` options__][sw-precache-options]:
 * `cacheId`: `[String]` - Not required but you should include this, it will give your service worker cache a unique name

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,15 @@ class SWPrecacheWebpackPlugin {
       // get the output path specified in webpack config
       const outputPath = compiler.options.output.path || DEFAULT_OUTPUT_PATH;
 
-      const staticFileGlobs = getAssetGlobs(stats.compilation).map(f => path.join(outputPath, f));
+      // get all assets outputted by webpack
+      const assetGlobs = getAssetGlobs(stats.compilation).map(f => path.join(outputPath, f));
+
+      const ignorePatterns = this.options.staticFileGlobsIgnorePatterns || []
+
+      // filter staticFileGlobs from ignorePatterns
+      const staticFileGlobs = assetGlobs.filter(text =>
+        (!ignorePatterns.some((regex) => regex.test(text)))
+      )
 
       const config = {
         staticFileGlobs,


### PR DESCRIPTION
There are various instances when ignoring webpack built files are necessary (gzipped built files, transient files, etc.)

Also solves #12.