### PR TITLE
Allow to use [hash] on importScripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ __plugin options__:
 * `dynamicUrlToDependencies`: `[Object<String,Array<String>]`
 * `handleFetch`: `[boolean]`
 * `ignoreUrlParametersMatching`: `[Array<Regex>]`
-* `importScripts`: `[Array<String>]`
+* `importScripts`: `[Array<String>]` - Add [hash] if you want to import a file generated with webpack [hash] ex. ['dist/some-[hash].js']
 * `logger`: `[function]`
 * `maximumFileSizeToCacheInBytes`: `[Number]`
 * `navigateFallbackWhitelist`: `[Array<RegExp>]`

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,11 @@ class SWPrecacheWebpackPlugin {
         config.replacePrefix = compiler.options.output.publicPath;
       }
 
+      // add hash to importScripts
+      const scripts = this.options.importScripts || [];
+      const importScripts = scripts.map(f => f.replace(/\[hash\]/g, stats.hash));
+      this.options.importScripts = importScripts;
+
       this.writeServiceWorker(compiler, config);
     });
   }


### PR DESCRIPTION
Hi, this is the enhancement for this [issue](https://github.com/goldhand/sw-precache-webpack-plugin/issues/19). This is the first time I write a webpack plugin, so please let me know if it was ok, or if I could do something better.