### PR TITLE
Use publicPath for importScripts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,8 +83,11 @@ class SWPrecacheWebpackPlugin {
       }
 
       // add hash to importScripts
+      const publicPath = compiler.options.output.publicPath || '';
       const scripts = this.options.importScripts || [];
-      const importScripts = scripts.map(f => f.replace(/\[hash\]/g, stats.hash));
+      const importScripts = scripts
+        .map(f => f.replace(/\[hash\]/g, stats.hash))
+        .map(f => path.join(publicPath, f));
       this.options.importScripts = importScripts;
 
       this.writeServiceWorker(compiler, config);


### PR DESCRIPTION
importScripts will make a request to the file path passed in. In cases where a `publicPath` is being used, the filename alone is insufficient, so the request fails.

e.g., if you just do `sw.[hash].js` and you have a `publicPath` of `/js/` then the file is served at `/js/sw.[hash].js` but the generated `sw.js` file will only have `importScripts('sw.[hash].js')`