### PR TITLE
Fix preserving the [hash] 

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,6 @@
+{
+  "ignore_dirs": [
+    ".git",
+    "node_modules"
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,8 @@ class SWPrecacheWebpackPlugin {
       // add hash to importScripts
       const publicPath = compiler.options.output.publicPath || '';
       const scripts = this.options.importScripts || [];
+      // keep the original scripts with [hash] tag
+      config.importScripts = scripts;
       const importScripts = scripts
         .map(f => f.replace(/\[hash\]/g, stats.hash))
         .map(f => path.join(publicPath, f));
@@ -103,6 +105,8 @@ class SWPrecacheWebpackPlugin {
         ...config,
         ...this.options,
       };
+
+    this.options.importScripts = config.importScripts;
 
     return del(filepath).then(() => {
       return swPrecache.write(filepath, workerOptions);

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ class SWPrecacheWebpackPlugin {
       ...DEFAULT_OPTIONS,
       ...options,
     };
+    this.overrides = {};
   }
 
   apply(compiler) {
@@ -85,12 +86,10 @@ class SWPrecacheWebpackPlugin {
       // add hash to importScripts
       const publicPath = compiler.options.output.publicPath || '';
       const scripts = this.options.importScripts || [];
-      // keep the original scripts with [hash] tag
-      config.importScripts = scripts;
       const importScripts = scripts
         .map(f => f.replace(/\[hash\]/g, stats.hash))
         .map(f => path.join(publicPath, f));
-      this.options.importScripts = importScripts;
+      this.overrides.importScripts = importScripts;
 
       this.writeServiceWorker(compiler, config);
     });
@@ -104,6 +103,7 @@ class SWPrecacheWebpackPlugin {
       workerOptions = {
         ...config,
         ...this.options,
+        ...this.overrides,
       };
 
     this.options.importScripts = config.importScripts;

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -169,6 +169,20 @@ test.serial('#shouldKeepTheHashTagOnImportScriptsAfterWritingSw(comiler, config)
 
 });
 
+test.serial('#shouldNotModifyImportScriptsSectionWhenNoHashIsProvided(comiler, config)', async t => {
+  t.plan(1);
+
+  const filepath = path.resolve(__dirname, 'tmp/service-worker.js');
+  const compiler = webpack(webpackConfig());
+  const plugin = new SWPrecacheWebpackPlugin({filepath,importScripts:['some_script.js']});
+
+  plugin.apply(compiler);
+  
+  await plugin.writeServiceWorker(compiler, plugin.options);
+  t.truthy(plugin.options.importScripts[0] === 'some_script.js', 'importScripts should not be modified');
+
+});
+
 test.cb('#apply(compiler)', t => {
   t.plan(2);
 

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -155,6 +155,20 @@ test.serial('#writeServiceWorker(comiler, config)', async t => {
 
 });
 
+test.serial('#shouldKeepTheHashTagOnImportScriptsAfterWritingSw(comiler, config)', async t => {
+  t.plan(1);
+
+  const filepath = path.resolve(__dirname, 'tmp/service-worker.js');
+  const compiler = webpack(webpackConfig());
+  const plugin = new SWPrecacheWebpackPlugin({filepath,importScripts:['some_sw-[hash].js']});
+
+  plugin.apply(compiler);
+  
+  await plugin.writeServiceWorker(compiler, plugin.options);
+  t.truthy(plugin.options.importScripts[0] === 'some_sw-[hash].js', 'hash should be preserve after writing the sw');
+
+});
+
 test.cb('#apply(compiler)', t => {
   t.plan(2);
 


### PR DESCRIPTION
When running webpack in watch mode, import scripts was returning always the first hash that was established.