### PR TITLE
Hook plugin to 'after-emit' to ensure async execution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ class SWPrecacheWebpackPlugin {
 
   apply(compiler) {
 
-    compiler.plugin('done', (stats) => {
+    compiler.plugin('after-emit', (compilation, done) => {
 
       // get the output path specified in webpack config
       const outputPath = compiler.options.output.path || DEFAULT_OUTPUT_PATH;
@@ -67,7 +67,7 @@ class SWPrecacheWebpackPlugin {
 
       // get all assets outputted by webpack
       const assetGlobs = Object
-        .keys(stats.compilation.assets)
+        .keys(compilation.assets)
         .map(f => path.join(outputPath, f));
 
       const ignorePatterns = this.options.staticFileGlobsIgnorePatterns || [];
@@ -94,11 +94,11 @@ class SWPrecacheWebpackPlugin {
 
       if (importScripts) {
         this.overrides.importScripts = importScripts
-          .map(f => f.replace(/\[hash\]/g, stats.hash)) // need to override importScripts with stats.hash
+          .map(f => f.replace(/\[hash\]/g, compilation.hash)) // need to override importScripts with stats.hash
           .map(f => url.resolve(publicPath, f));  // add publicPath to importScripts
       }
 
-      this.writeServiceWorker(compiler, config);
+      this.writeServiceWorker(compiler, config).then(done);
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ class SWPrecacheWebpackPlugin {
 
   apply(compiler) {
 
-    compiler.plugin('after-emit', (compilation, done) => {
+    compiler.plugin('after-emit', (compilation, callback) => {
 
       // get the output path specified in webpack config
       const outputPath = compiler.options.output.path || DEFAULT_OUTPUT_PATH;
@@ -98,7 +98,10 @@ class SWPrecacheWebpackPlugin {
           .map(f => url.resolve(publicPath, f));  // add publicPath to importScripts
       }
 
-      this.writeServiceWorker(compiler, config).then(done);
+      const done = () => callback();
+      const error = (err) => callback(err);
+
+      this.writeServiceWorker(compiler, config).then(done, error);
     });
   }
 


### PR DESCRIPTION
This fixes #34 

I changed the hook this plugin register itself on from `done` to `after-emit`. The latter supports asynchronous execution, which is necessary as ´sw-prefetch´ doesn't support synchronous use.
From what I can tell we should already have all the correct files and stats we need on this hook.