### PR TITLE
pass force option to `del`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const
 const DEFAULT_OPTIONS = {
   cacheId: DEFAULT_CACHE_ID,
   filename: DEFAULT_WORKER_FILENAME,
-  forceDelete: false
+  forceDelete: true
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const
 const DEFAULT_OPTIONS = {
   cacheId: DEFAULT_CACHE_ID,
   filename: DEFAULT_WORKER_FILENAME,
+  forceDelete: false
 };
 
 /**
@@ -116,7 +117,7 @@ class SWPrecacheWebpackPlugin {
         ...this.overrides,
       };
 
-    return del(filepath).then(() => {
+    return del(filepath, { ...this.options.forceDelete }).then(() => {
       return swPrecache.write(filepath, workerOptions);
     });
   }


### PR DESCRIPTION
It's possible some users want the service-worker.js to be created in a different path. 

`del` needs a `force = true` option to be able to delete files from a different path