### PR TITLE
Add support for staticFileGlobs option and stripPrefix(Multi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ __plugin options__:
 * `filename`: `[String]` - Service worker filename, default is `service-worker.js`
 * `filepath`: `[String]` - Service worker path and name, default is to use `webpack.output.path` + `options.filename`. This will overried `filename`. *Warning: Make the service worker available in the same directory it will be needed. This is because the scope of the service worker is defined by the directory the worker exists.*
 * `staticFileGlobsIgnorePatterns`: `[RegExp]` - Define an optional array of regex patterns to filter out of staticFileGlobs (see below)
+* `mergeStaticsConfig`: `[boolean]` - Merge provided staticFileGlobs and stripPrefix(Multi) with webpack's config, rather than having those take precedence, default is false.
 * `minify`: `[boolean]` - Set to true to minify and uglify the generated service-worker, default is false.
 * `forceDelete`: `[boolean]` - Pass force option to del, default is false.
 
@@ -84,11 +85,11 @@ __plugin options__:
 * `logger`: `[function]`
 * `maximumFileSizeToCacheInBytes`: `[Number]`
 * `navigateFallbackWhitelist`: `[Array<RegExp>]`
-* `replacePrefix`: `[String]`
+* `replacePrefix`: `[String]` - Should only be used in conjunction with `stripPrefix`
 * `runtimeCaching`: `[Array<Object>]`
-* `staticFileGlobs`: `[Array<String>]` - Will be merged with your bundles' emitted assets.
+* `staticFileGlobs`: `[Array<String>]` - If `mergeStaticsConfig=true`: will be merged with your bundles' emitted assets. Otherwise this property takes precedence and emitted assets won't be included.
 * `stripPrefix`: `[String]` - Same as `stripPrefixMulti[stripPrefix] = ''`
-* `stripPrefixMulti`: `[Object<String,String>]` - Will be merged with your webpack config's `output.path + '/'` for stripping prefixes.
+* `stripPrefixMulti`: `[Object<String,String>]` - If `mergeStaticsConfig=true`: will be merged with your webpack's output.path => publicPath for stripping prefixes. Otherwise this property (or `stripPrefix`) takes precedence and Webpack's output path won't be replaced.
 * `templateFilePath`: `[String]`
 * `verbose`: `[boolean]`
 
@@ -102,6 +103,25 @@ plugins: [
     {
       cacheId: "my-project-name",
       filename: "my-project-service-worker.js",
+    }
+  ),
+]
+```
+
+Here's a more elaborate example with `mergeStaticsConfig: true` and `staticFileGlobsIgnorePatterns`. `mergeStaticsConfig: true` allows you to add some additional static file globs to the emitted ServiceWorker file alongside Webpack's emitted assets. `staticFileGlobsIgnorePatterns` can be used to avoid including sourcemap file references in the generated ServiceWorker.
+```javascript
+plugins: [
+  new SWPrecacheWebpackPlugin(
+    {
+      cacheId: "my-project-name",
+      filename: "my-project-service-worker.js",
+      staticFileGlobs: [
+        'src/static/img/**.*',
+        'src/static/styles.css',
+      ],
+      stripPrefix: 'src/static/', // stripPrefixMulti is also supported
+      mergeStaticsConfig: true, // if you don't set this to true, you won't see any webpack-emitted assets in your serviceworker config
+      staticFileGlobsIgnorePatterns: [/\.map$/], // use this to ignore sourcemap files
     }
   ),
 ]

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ __plugin options__:
 * `navigateFallbackWhitelist`: `[Array<RegExp>]`
 * `replacePrefix`: `[String]`
 * `runtimeCaching`: `[Array<Object>]`
-* `staticFileGlobs`: `[Array<String>]` - Omit this to allow the plugin to cache all your bundles' emitted assets.
-* `stripPrefix`: `[String]` - Omit this to use your webpack config's `output.path + '/'` for stripping prefixes.
+* `staticFileGlobs`: `[Array<String>]` - Will be merged with your bundles' emitted assets.
+* `stripPrefix`: `[String]` - Same as `stripPrefixMulti[stripPrefix] = ''`
+* `stripPrefixMulti`: `[Object<String,String>]` - Will be merged with your webpack config's `output.path + '/'` for stripping prefixes.
 * `templateFilePath`: `[String]`
 * `verbose`: `[boolean]`
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ const DEFAULT_OPTIONS = {
  * @param {array} [options.runtimeCaching]
  * @param {array} [options.staticFileGlobs]
  * @param {string} [options.stripPrefix]
+ * @param {string} [options.stripPrefixMulti]
  * @param {string} [options.templateFilePath]
  * @param {boolean} [options.verbose]
  *

--- a/src/index.js
+++ b/src/index.js
@@ -99,18 +99,14 @@ class SWPrecacheWebpackPlugin {
 
       if (this.options.stripPrefix) {
         // add stripPrefix to stripPrefixMulti and delete it so we make sure only stripPrefixMulti is used
-        config.stripPrefixMulti[this.options.stripPrefix] = '';
+        config.stripPrefixMulti[this.options.stripPrefix] = this.options.replacePrefix || '';
         delete this.options.stripPrefix;
+        delete this.options.replacePrefix;
       }
 
       if (outputPath) {
         // strip the webpack config's output.path
-        config.stripPrefixMulti[`${outputPath}${path.sep}`] = '';
-      }
-
-      if (publicPath) {
-        // prepend the public path to the resources
-        config.replacePrefix = publicPath;
+        config.stripPrefixMulti[`${outputPath}${path.sep}`] = publicPath || '';
       }
 
       if (importScripts) {

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -20,6 +20,7 @@ const DEFAULT_OPTIONS = {
   cacheId: 'sw-precache-webpack-plugin',
   filename: 'service-worker.js',
   forceDelete: false,
+  mergeStaticsConfig: false,
   minify: false,
 };
 


### PR DESCRIPTION
This allows using a mixture of webpack-generated globs and passed staticFileGlobs, as well as the stripPrefix(Multi) to go with it. 

Thus, this becomes possible:

```js
new SWPrecacheWebpackPlugin({
  // ...
  staticFileGlobs: [
    'src/static/img/**.*',
    'src/static/styles.css',
  ],
  stripPrefix: 'src/static/',
  // ...
})
```

Or even this:

```js
new SWPrecacheWebpackPlugin({
  // ...
  staticFileGlobs: [
    'src/static/img/**.*',
    'src/generated/**.js',
  ],
  stripPrefixMulti: {
    'src/static/': '',
    'src/generated/': 'js/',
  },
  // ...
})
```