### PR TITLE
Remove deprecated eslint-plugin-babel options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,9 +6,6 @@
   },
 
   "parser": "babel-eslint",
-  "plugins": [
-    "babel"
-  ],
 
   "parserOptions": {
     "ecmaVersion": 7,
@@ -44,7 +41,7 @@
     "yoda": [2, "never"],
 
     "no-var": 0,
-    "generator-star-spacing": 0,
+    "generator-star-spacing": [2, "before"],
 
     "valid-jsdoc": [2, {
       "prefer": {
@@ -52,9 +49,6 @@
       },
       "requireParamDescription": false,
     }],
-
-    "babel/object-shorthand": 0,
-    "babel/generator-star-spacing": [2, {"before": true, "after": false}],
 
     "no-alert": 2,
     "no-array-constructor": 2,

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "babel-preset-stage-0": "^6.16.0",
     "bluebird": "^3.4.7",
     "eslint": "^3.7.1",
-    "eslint-plugin-babel": "^4.0.0",
     "git-release-notes": "0.0.2",
     "mkdirp": "^0.5.1",
     "sinon": "^1.17.7",


### PR DESCRIPTION
And uninstall `eslint-plugin-babel` now that it's no longer used.

This fixes a deprecation warning.