### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,16 @@ __plugin options__:
 * `staticFileGlobsIgnorePatterns`: `[RegExp]` - Define an optional array of regex patterns to filter out of staticFileGlobs (see below)
 * `mergeStaticsConfig`: `[boolean]` - Merge provided staticFileGlobs and stripPrefixMulti with webpack's config, rather than having those take precedence, default is false.
 * `minify`: `[boolean]` - Set to true to minify and uglify the generated service-worker, default is false.
-* `forceDelete`: `[boolean]` - Pass force option to del, default is false.
 
 [__`sw-precache` options__][sw-precache-options]:
-* `cacheId`: `[String]` - Not required but you should include this, it will give your service worker cache a unique name
-* `directoryIndex`: `[String]`
-* `dynamicUrlToDependencies`: `[Object<String,Array<String>]`
-* `handleFetch`: `[boolean]`
-* `ignoreUrlParametersMatching`: `[Array<Regex>]`
+Pass any option from `sw-precache` into your configuration. Some of these will be automatically be populated if you do not specify the value and a couple others will be modified to be more compatible with webpack. Options that are populated / modified:
+
+* `cacheId`: `[String]` - Not required but you should include this, it will give your service worker cache a unique name. Defaults to "sw-precache-webpack-plugin".
 * `importScripts`: `[Array<String>]` - Add [hash] if you want to import a file generated with webpack [hash] ex. ['dist/some-[hash].js']
-* `logger`: `[function]`
-* `maximumFileSizeToCacheInBytes`: `[Number]`
-* `navigateFallbackWhitelist`: `[Array<RegExp>]`
 * `replacePrefix`: `[String]` - Should only be used in conjunction with `stripPrefix`
-* `runtimeCaching`: `[Array<Object>]`
 * `staticFileGlobs`: `[Array<String>]` - Omit this to allow the plugin to cache all your bundles' emitted assets. If `mergeStaticsConfig=true`: this value will be merged with your bundles' emitted assets, otherwise this value is just passed to `sw-precache` and emitted assets won't be included.
 * `stripPrefix`: `[String]` - Same as `stripPrefixMulti[stripPrefix] = ''`
 * `stripPrefixMulti`: `[Object<String,String>]` - Omit this to use your webpack config's `output.path + '/': output.publicPath`. If `mergeStaticsConfig=true`, this value will be merged with your webpack's `output.path: publicPath` for stripping prefixes. Otherwise this property will be passed directly to `sw-precache` and Webpack's output path won't be replaced.
-* `templateFilePath`: `[String]`
-* `verbose`: `[boolean]`
 
 
 _Note that all configuration options are optional. `SWPrecacheWebpackPlugin` will by default use all your assets emitted by webpack's compiler for the `staticFileGlobs` parameter and your webpack config's `{[output.path + '/']: output.publicPath}` as the `stripPrefixMulti` parameter. This behavior is probably what you want, all your webpack assets will be cached by your generated service worker. Just don't pass any arguments when you initialize this plugin, and let this plugin handle generating your `sw-precache` configuration._

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ SW Precache Webpack Plugin
 ==========================
 [![NPM version][npm-img]][npm-url]
 [![NPM downloads][npm-downloads-img]][npm-url]
-[![Dependency Status][daviddm-img]][daviddm-url]
 [![CircleCI][circleci-img]][circleci-url]
 
 __`SWPrecacheWebpackPlugin`__ is a [webpack][webpack] plugin for using [service workers][sw-guide] to cache your external project dependencies. It will generate a service worker file using [sw-precache][sw-precache] and add it to your build directory.
@@ -147,6 +146,8 @@ plugins: [
 Webpack Dev Server Support
 --------------------------
 Currently `SWPrecacheWebpackPlugin` will not work with `Webpack Dev Server`. If you wish to test the service worker locally, you can use simple a node server [see example project][example-project] or `python SimpleHTTPServer` from your build directory. I would suggest pointing your node server to a different port than your usual local development port and keeping the precache service worker out of your [local configuration (example)][webpack-local-config-example].
+
+There will likely never be `webpack-dev-server` support. `sw-precache` needs physical files in order to generate the service worker. Webpack-dev-server files are in-memory. It is only possible to provide `sw-precache` with globs to find these files. It will follow the glob pattern and generate a list of file names to cache.
 
 
 Contributing

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -4,7 +4,7 @@
 
 import test from 'ava';
 import webpack from 'webpack';
-import SWPrecacheWebpackPlugin from '../lib';
+import SWPrecacheWebpackPlugin from '../src';
 import path from 'path';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
@@ -16,7 +16,6 @@ const DEFAULT_OPTIONS = {
   filename: 'service-worker.js',
   importScripts: [],
   staticFileGlobsIgnorePatterns: [],
-  forceDelete: false,
   mergeStaticsConfig: false,
   minify: false,
 };
@@ -297,13 +296,13 @@ test.serial('uses UglifyJS to minify code', async t => {
       compiler2.plugin('after-emit', (compilation) => {
         withMinificationPlugin.configure(compiler2, compilation);
         resolve(withMinificationPlugin.createServiceWorker());
-      })
+      });
       runCompiler(compiler2);
     }
   );
 
   // Uglify should be at least 1/3 the size of non uglifyied
-  const withMinBytes = Buffer.byteLength(withMinificationFileContents)
+  const withMinBytes = Buffer.byteLength(withMinificationFileContents);
   const withoutMinBytes = Buffer.byteLength(withoutMinificationFileContents);
 
   t.true(withMinBytes < withoutMinBytes);
@@ -438,4 +437,22 @@ test.serial('@stripPrefixMulti can be merged', async t => {
   const actual = plugin.workerOptions.stripPrefixMulti;
 
   t.deepEqual(actual, expected);
+});
+
+test.serial('@filepath will add warning', async t => {
+  t.plan(2);
+
+  const compiler = webpack(webpackConfig());
+  const plugin = new SWPrecacheWebpackPlugin({
+    filepath: path.resolve(outputPath, 'foo.js'),
+  });
+
+  plugin.apply(compiler);
+
+  t.truthy(plugin.warnings.length === 0);
+
+  await runCompiler(compiler);
+
+  t.truthy(plugin.warnings.length === 1);
+
 });

--- a/test/plugin.spec.js
+++ b/test/plugin.spec.js
@@ -7,12 +7,7 @@ import webpack from 'webpack';
 import SWPrecacheWebpackPlugin from '../lib';
 import path from 'path';
 import fs from 'fs';
-import sinon from 'sinon';
-import UglifyJS from 'uglify-js';
 import mkdirp from 'mkdirp';
-import bluebirdPromise from 'bluebird';
-bluebirdPromise.promisifyAll(fs);
-bluebirdPromise.promisifyAll(mkdirp);
 
 const outputPath = path.resolve(__dirname, 'tmp');
 
@@ -26,7 +21,7 @@ const DEFAULT_OPTIONS = {
   minify: false,
 };
 
-const webpackConfig = () => {
+const webpackConfig = (hash = true) => {
 
   const config = {
     context: __dirname,
@@ -39,6 +34,10 @@ const webpackConfig = () => {
       publicPath: 'http://localhost:3000/assets/',
     },
   };
+
+  if (hash) {
+    config.output.filename = '[name]-[hash].js';
+  }
 
   return config;
 };
@@ -63,8 +62,8 @@ const fsExists = (fp) => new Promise(
 );
 
 
-test.before(async () => {
-  await mkdirp(outputPath);
+test.before(() => {
+  mkdirp.sync(outputPath);
 });
 
 /** SWPrecacheWebpackPlugin constructor paramaters */
@@ -182,17 +181,44 @@ test('can set minify', t => {
 
 /** SWPrecacheWebpackPlugin methods */
 
-test.serial('#writeServiceWorker(compiler, config)', async t => {
+test.skip('#configure()', async t => {
+  // TODO: test configure() method
+  t.pass();
+});
+
+test.serial('#createServiceWorker()', async t => {
+  t.plan(1);
+
+  const compiler = webpack(webpackConfig());
+  const plugin = new SWPrecacheWebpackPlugin();
+
+  compiler.plugin('after-emit', (compilation, callback) => {
+    plugin.configure(compiler, compilation);
+    return callback();
+  });
+
+  await runCompiler(compiler);
+
+  t.truthy(await plugin.createServiceWorker(), 'generate something');
+});
+
+test.serial('#writeServiceWorker(serviceWorker, compiler, callback)', async t => {
   t.plan(2);
 
   const filepath = path.resolve(__dirname, 'tmp/service-worker.js');
   const compiler = webpack(webpackConfig());
   const plugin = new SWPrecacheWebpackPlugin({filepath});
+  const serviceWorker = 'foo';
+
+  t.falsy(await fsExists(filepath), 'service-worker should not exist yet');
 
   plugin.apply(compiler);
 
-  t.falsy(await fsExists(filepath), 'service-worker should not exist yet');
-  await plugin.writeServiceWorker(compiler, plugin.options);
+  compiler.plugin('after-emit', (compilation, callback) => {
+    plugin.writeServiceWorker(serviceWorker, compiler, callback);
+  });
+  await runCompiler(compiler);
+
   t.truthy(await fsExists(filepath), 'service-worker should exist');
 
 });
@@ -213,7 +239,7 @@ test.cb('#apply(compiler)', t => {
 
 });
 
-test.serial('should keep [hash] in importScripts after writing SW', async t => {
+test.serial('should keep [hash] in importScripts after configuring SW', async t => {
   t.plan(1);
 
   const filepath = path.resolve(__dirname, 'tmp/service-worker.js');
@@ -221,8 +247,11 @@ test.serial('should keep [hash] in importScripts after writing SW', async t => {
   const plugin = new SWPrecacheWebpackPlugin({filepath, importScripts: ['some_sw-[hash].js']});
 
   plugin.apply(compiler);
+  compiler.plugin('after-emit', (compilation) => {
+    plugin.configure(compiler, compilation);
+  });
+  await runCompiler(compiler);
 
-  await plugin.writeServiceWorker(compiler, plugin.options);
   t.truthy(plugin.options.importScripts[0] === 'some_sw-[hash].js', 'hash should be preserve after writing the sw');
 
 });
@@ -235,39 +264,52 @@ test.serial('should not modify importScripts value when no hash is provided', as
   const plugin = new SWPrecacheWebpackPlugin({filepath, importScripts: ['some_script.js']});
 
   plugin.apply(compiler);
+  compiler.plugin('after-emit', (compilation) => {
+    plugin.configure(compiler, compilation);
+  });
+  await runCompiler(compiler);
 
-  await plugin.writeServiceWorker(compiler, plugin.options);
   t.truthy(plugin.options.importScripts[0] === 'some_script.js', 'importScripts should not be modified');
 
 });
 
 test.serial('uses UglifyJS to minify code', async t => {
-  const filepath = path.resolve(__dirname, 'tmp/service-worker.js');
-  const compiler1 = webpack(webpackConfig());
-  const withoutMinificationPlugin = new SWPrecacheWebpackPlugin({filepath, minify: false});
+  t.plan(2);
+
+  const compiler1 = webpack(webpackConfig(0));
+  const withoutMinificationPlugin = new SWPrecacheWebpackPlugin({minify: false});
   withoutMinificationPlugin.apply(compiler1);
-  await withoutMinificationPlugin.writeServiceWorker(compiler1, withoutMinificationPlugin.options);
-  const withoutMinificationFileContents = await fs.readFileAsync(filepath);
-  // spy on uglify
-  const uglifyMock = sinon.mock(UglifyJS);
-  const minifyExpectation = uglifyMock.expects('minify');
-  minifyExpectation.once();
-  minifyExpectation.returns({code: 'minified string', map: null});
-  minifyExpectation.withExactArgs({
-    'service-worker.js': withoutMinificationFileContents.toString(),
-  }, {
-    fromString: true,
-  });
-  const compiler2 = webpack(webpackConfig());
-  const withMinificationPlugin = new SWPrecacheWebpackPlugin({filepath, minify: true});
+  const withoutMinificationFileContents = await new Promise(
+    resolve => {
+      runCompiler(compiler1);
+      compiler1.plugin('after-emit', (compilation) => {
+        withoutMinificationPlugin.configure(compiler1, compilation);
+        resolve(withoutMinificationPlugin.createServiceWorker());
+      });
+    }
+  );
+
+  const compiler2 = webpack(webpackConfig(0));
+  const withMinificationPlugin = new SWPrecacheWebpackPlugin({minify: true});
   withMinificationPlugin.apply(compiler2);
-  await withMinificationPlugin.writeServiceWorker(compiler2, withMinificationPlugin.options);
-  // verify uglify js was called correctly
-  minifyExpectation.verify();
-  uglifyMock.restore();
-  // check if minified code was written correctly
-  const withMinificationFileContents = await fs.readFileAsync(filepath);
-  t.deepEqual(withMinificationFileContents.toString(), 'minified string');
+  const withMinificationFileContents = await new Promise(
+    resolve => {
+      compiler2.plugin('after-emit', (compilation) => {
+        withMinificationPlugin.configure(compiler2, compilation);
+        resolve(withMinificationPlugin.createServiceWorker());
+      })
+      runCompiler(compiler2);
+    }
+  );
+
+  // Uglify should be at least 1/3 the size of non uglifyied
+  const withMinBytes = Buffer.byteLength(withMinificationFileContents)
+  const withoutMinBytes = Buffer.byteLength(withoutMinificationFileContents);
+
+  t.true(withMinBytes < withoutMinBytes);
+
+  // even 2x uglifyied size should be less than regular
+  t.true(withMinBytes * 2 < withoutMinBytes, 'Uglified is more than half the size of non-uglified');
 });
 
 
@@ -284,7 +326,8 @@ test.serial('@staticFileGlobs generates default value', async t => {
 
   await runCompiler(compiler);
 
-  const expected = [path.resolve(outputPath, 'main.js')];
+  const {hash} = await runCompiler(compiler);
+  const expected = [path.resolve(outputPath, `main-${hash}.js`)];
   const actual = plugin.workerOptions.staticFileGlobs;
 
   t.deepEqual(actual, expected);
@@ -321,8 +364,8 @@ test.serial('@staticFileGlobs can be merged', async t => {
 
   plugin.apply(compiler);
 
-  await runCompiler(compiler);
-  const expected = [path.resolve(outputPath, 'main.js'), ...staticFileGlobs];
+  const {hash} = await runCompiler(compiler);
+  const expected = [path.resolve(outputPath, `main-${hash}.js`), ...staticFileGlobs];
   const actual = plugin.workerOptions.staticFileGlobs;
 
   t.deepEqual(actual, expected);


### PR DESCRIPTION
Moved things out of `apply` so they would be easier to use and test.

Opted to use webpack's `compiler.outputFileSystem` methods for writing to the file system since:
```javascript
  apply(compiler) {
    compiler.plugin('emit', (compilation, callback) => {
      const file = 'some data';
      compilation.assets['foo.js'] = {
        source: () => file,
        size: () => Buffer.byteLength(file),
      };
    });
  }
```
will not work (the physical files need to be present for the `sw-precache` to be generated.

Had hoped to get something for `webpack-dev-server` working but given the mentioned problem, have come to the conclusion that it is impossible.