### PR TITLE
Avoid promisifying filesystem operations (see #81)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,17 +194,15 @@ class SWPrecacheWebpackPlugin {
   }
 
   writeServiceWorker(serviceWorker, compiler) {
-    const promisify = func => (...args) => new Promise((resolve, reject) => func(...args, (err, result) => {
-      return err ? reject(err) : resolve(result);
-    }));
-    const mkdirp = promisify(compiler.outputFileSystem.mkdirp);
-    const writeFile = promisify(compiler.outputFileSystem.writeFile);
-
     const {filepath} = this.workerOptions;
+    const {mkdirp, writeFile} = compiler.outputFileSystem;
 
     // use the outputFileSystem api to manually write service workers rather than adding to the compilation assets
-    return mkdirp(path.resolve(filepath, '..'))
-      .then(() => writeFile(filepath, serviceWorker));
+    return new Promise((resolve) => {
+      mkdirp(path.resolve(filepath, '..'), () => {
+        writeFile(filepath, serviceWorker, resolve);
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
The `promisify` function looks fine but is (incorrectly?) desugared to a `func.apply(undefined, args.concat...)` call.
This call is inserted by `babel` because `promisify` is using the `func(...args)` syntax.
The `memory-fs` package `webpack-dev-server` uses for file operations relies on implicitly bound functions and breaks when `this == undefined`.
To avoid the issue `writeServiceWorker` now uses the normal callback-style API.
(xref #81)