### PR TITLE
Moimael multiple instance example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,27 @@ plugins: [
 ]
 ```
 
+If you have multiple bundles outputted by webpack, you can create a service worker for each, so clients don't download a lot of unused assets.
+
+```javascript
+...Object.keys(apps())
+  .map(app => new SWPrecacheWebpackPlugin({
+    cacheId: `${app}`,
+    filename: `${app}-service-worker.js`,
+    stripPrefix: 'src/static',
+    staticFileGlobs: [
+      'src/static/js/manifest.*.js',
+      'src/static/js/vendor.*.js',
+      `src/static/js/${app}_vendor.*.js`,
+      `src/static/js/${app}.*.js`,
+      `src/static/css/${app}.*.css`,
+      `src/static/${app}.html`,
+      'src/static/fonts/*',
+    ],
+  }),
+)
+```
+
 ### `importSripts` usage example
 Accepts an array of `<String|Object>`'s. `String` entries are legacy supported. Use `filename` instead.
 

--- a/README.md
+++ b/README.md
@@ -120,25 +120,57 @@ plugins: [
 ]
 ```
 
-If you have multiple bundles outputted by webpack, you can create a service worker for each, so clients don't download a lot of unused assets.
+### Generating Multiple Service Workers
+If you have multiple bundles outputted by webpack, you can create a service worker for each. This can be useful if you have a multi-page application with bundles specific to each page and you don't need to download every bundle (among other reasons).
 
 ```javascript
-...Object.keys(apps())
-  .map(app => new SWPrecacheWebpackPlugin({
-    cacheId: `${app}`,
-    filename: `${app}-service-worker.js`,
-    stripPrefix: 'src/static',
-    staticFileGlobs: [
-      'src/static/js/manifest.*.js',
-      'src/static/js/vendor.*.js',
-      `src/static/js/${app}_vendor.*.js`,
-      `src/static/js/${app}.*.js`,
-      `src/static/css/${app}.*.css`,
-      `src/static/${app}.html`,
-      'src/static/fonts/*',
-    ],
-  }),
-)
+/**
+ * @module {Object} webpack.config
+ */
+const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
+
+/** @constant {Object} Application entry points and bundle names */
+const APPS = {
+  home: path.resolve(__dirname, 'src/home'),
+  posts: path.resolve(__dirname, 'src/posts'),
+  users: path.resolve(__dirname, 'src/users'),
+}
+
+/** @constant {string} build directory name */
+const OUTPUT_DIR = 'dist';
+
+/**
+ * @alias webpack.config
+ * @type {Object}
+ */
+module.exports = {
+
+  entry: APPS,
+
+  output: {
+    path: path.resolve(__dirname, OUTPUT_DIR),
+    filename: '[name].[hash].js',
+  },
+
+  plugins: [
+    // iterate over each `entry[app]` key.
+    ...Object.keys(APPS)
+      .map(app => new SWPrecacheWebpackPlugin({
+        cacheId: `${app}`,
+        filename: `${app}-service-worker.js`,
+        stripPrefix: OUTPUT_DIR,
+        // We specify paths to the compiled destinations of resources for each "app's"
+        // bundled resources. This is one way to separate bundled assets for each
+        // application.
+        staticFileGlobs: [
+          `${OUTPUT_DIR}/js/manifest.*.js`,
+          `${OUTPUT_DIR}/js/${app}.*.js`,
+          `${OUTPUT_DIR}/css/${app}.*.css`,
+          `${OUTPUT_DIR}/${app}.html`,
+        ],
+      })),
+  ],
+}
 ```
 
 ### `importSripts` usage example


### PR DESCRIPTION
@moimael can you review this before I merge? I noticed that in your example you were pointing to the `src/<file>` instead of the generated build directory (unless your ouput.path was `src/static`).  I added the `output` config to clarify that the paths are to the target output dir.

I am also assuming that `apps()` from your example was referring to the entry object. I expanded that and moved it to `APPS`.