### PR TITLE
Don't lose implicit instance of `outputFileSystem` (fixes #109)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "bluebird": "^3.4.7",
     "eslint": "^3.16.1",
     "git-release-notes": "1.0.0",
+    "memory-fs": "^0.4.1",
     "mkdirp": "^0.5.1",
     "sinon": "^1.17.7",
     "webpack": "^3.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -195,12 +195,22 @@ class SWPrecacheWebpackPlugin {
 
   writeServiceWorker(serviceWorker, compiler) {
     const {filepath} = this.workerOptions;
-    const {mkdirp, writeFile} = compiler.outputFileSystem;
+    const {outputFileSystem} = compiler;
 
     // use the outputFileSystem api to manually write service workers rather than adding to the compilation assets
-    return new Promise((resolve) => {
-      mkdirp(path.resolve(filepath, '..'), () => {
-        writeFile(filepath, serviceWorker, resolve);
+    return new Promise((resolve, reject) => {
+      outputFileSystem.mkdirp(path.resolve(filepath, '..'), (mkdirErr) => {
+        if (mkdirErr) {
+          reject(mkdirErr);
+          return;
+        }
+        outputFileSystem.writeFile(filepath, serviceWorker, writeError => {
+          if (writeError) {
+            reject(writeError);
+          } else {
+            resolve();
+          }
+        });
       });
     });
   }


### PR DESCRIPTION
Addresses https://github.com/goldhand/sw-precache-webpack-plugin/issues/109
Also fixes error swallowing and tests compatibility with `memory-fs`