### PR TITLE
Fixed service worker file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Then you would just register it in your application:
 ```javascript
 (function() {
   if('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/my-service-worker.js');
+    navigator.serviceWorker.register('/service-worker.js');
   }
 })();
 ```


### PR DESCRIPTION
The example in README file uses the file name `my-service-worker.js` although the webpack config uses the file name `service-worker.js` 