### PR TITLE
Replacing prepublish script with prepare.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,6 @@
 node_modules/
-src/
 examples/
 test/
 .github/
 circle.yml
-.babelrc
 .eslintrc

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Webpack plugin for using service workers",
   "main": "lib/index.js",
   "scripts": {
-    "prepublish": "make build",
+    "prepare": "make build",
     "version": "make changelog && git add -p CHANGELOG.md && git checkout CHANGELOG.md",
     "test:unit": "make unit_test",
     "test:integration": "make integration_test",


### PR DESCRIPTION
If someone wanted to install this from github instead of npm (say because they wanted a version that hadn't been published to npm), the `prepublish` script won't run and they'll be left without the actual built `lib` files.

See:
https://github.com/npm/npm/issues/3055
http://blog.npmjs.org/post/161081169345/v500
https://twitter.com/maybekatz/status/860363896443371520