### PR TITLE
Allow any version of webpack as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "./test"
   },
   "peerDependencies": {
-    "webpack": "^1 || ^2 || ^2.1.0-beta || ^2.2.0-beta || ^3"
+    "webpack": "*"
   },
   "dependencies": {
     "del": "^2.2.2",


### PR DESCRIPTION
Webpack 4 alpha has been released. In preparation for v4,
it seems reasonable to change this to allow `*`. This should cut
down on maintenance and avoid unnecessarily blocking folks
from updating going forward.