### PR TITLE
Remove dontCacheBustUrlsMatching from doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ module.exports = {
     new SWPrecacheWebpackPlugin(
       {
         cacheId: 'my-project-name',
-        dontCacheBustUrlsMatching: /\.\w{8}\./,
         filename: 'service-worker.js',
         minify: true,
         navigateFallback: PUBLIC_PATH + 'index.html',


### PR DESCRIPTION
Remove dontCacheBustUrlsMatching from doc because this option does not exist